### PR TITLE
Use a fixed timestep

### DIFF
--- a/src/de/nulldesign/nd2d/display/World2D.as
+++ b/src/de/nulldesign/nd2d/display/World2D.as
@@ -283,31 +283,33 @@ package de.nulldesign.nd2d.display {
 			accumulator += elapsed;
 
 			while (accumulator >= dt) {
-
-				if(scene && context3D && context3D.driverInfo != "Disposed") {
-					context3D.clear(scene.br, scene.bg, scene.bb, 1.0);
-
-					if(!isPaused) {
-						scene.stepNode(dt, t);
-					}
-
-					if(deviceWasLost) {
-						ShaderCache.getInstance().handleDeviceLoss();
-						scene.handleDeviceLoss();
-						deviceWasLost = false;
-					}
-
-					statsObject.totalDrawCalls = 0;
-					statsObject.totalTris = 0;
-
-					scene.drawNode(context3D, camera, false, statsObject);
-
-					context3D.present();
-				}
-
+				step(dt, t);
 				t += dt;
 				accumulator -= dt;
 
+			}
+		}
+
+		protected function step(dt:Number, t:Number):void {
+			if(scene && context3D && context3D.driverInfo != "Disposed") {
+				context3D.clear(scene.br, scene.bg, scene.bb, 1.0);
+
+				if(!isPaused) {
+					scene.stepNode(dt, t);
+				}
+
+				if(deviceWasLost) {
+					ShaderCache.getInstance().handleDeviceLoss();
+					scene.handleDeviceLoss();
+					deviceWasLost = false;
+				}
+
+				statsObject.totalDrawCalls = 0;
+				statsObject.totalTris = 0;
+
+				scene.drawNode(context3D, camera, false, statsObject);
+
+				context3D.present();
 			}
 		}
 


### PR DESCRIPTION
When toggling the displayState of the stage to full screen and back, I was seeing a dramatic drop in fps temporarily, which was causing the elapsed time to spike.  This invariability with elapsed is problematic when you do things like rely on a sprite never moving more than 32 pixels in a frame or something..

I've slightly modified the main loop to make use of the solution presented on http://gafferongames.com/game-physics/fix-your-timestep

If this seems to be more of a specific use-case based approach, then the other issue is not being able to fully override World2D#gameLoop() because of the internal variables/methods in Stage2D.
